### PR TITLE
Ender integration, package.json & module/amd

### DIFF
--- a/ender.js
+++ b/ender.js
@@ -1,0 +1,16 @@
+(function ($) {
+  var radio = require('radio');
+
+  function integrate(meth) {
+    return function() {
+      var r = radio(arguments[0]);
+      return r[meth].apply(r, Array.prototype.slice.call(arguments, 1));
+    };
+  }
+
+  $.ender({
+    subscribe: integrate('add'),
+    unsubscribe: integrate('remove'),
+    broadcast: integrate('broadcast')
+  });
+}(ender));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "radio",
+  "description": "A small dependency-free publish/subscribe javascript library",
+  "version": "0.1.0",
+  "homepage": "http://radio.uxder.com/",
+  "author": "Scott Murphy, @hellocreation",
+  "keywords": [ "pubsub", "events", "ender" ],
+  "main": "./radio.js",
+  "ender": "./ender.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uxder/Radio.git"
+  }
+}

--- a/radio.js
+++ b/radio.js
@@ -25,7 +25,12 @@
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE.
  */
-(function(global) {
+(function (name, global, definition) {
+	if (typeof module !== 'undefined') module.exports = definition(name, global);
+	else if (typeof define === 'function' && typeof define.amd  === 'object') define(definition);
+	else global[name] = definition(name, global);
+})('radio', this, function (name, global) {
+
 	"use strict";
 
 	/**
@@ -156,6 +161,5 @@
 		}
 	};
 
-	//add radio to window object
-	global.radio = global.radio || radio;
-})(window);
+	return radio;
+});

--- a/tests/ender/ender.js
+++ b/tests/ender/ender.js
@@ -1,0 +1,284 @@
+/*!
+  * =============================================================
+  * Ender: open module JavaScript framework (https://ender.no.de)
+  * Build: ender build ../..
+  * =============================================================
+  */
+
+/*!
+  * Ender: open module JavaScript framework (client-lib)
+  * copyright Dustin Diaz & Jacob Thornton 2011 (@ded @fat)
+  * http://ender.no.de
+  * License MIT
+  */
+!function (context) {
+
+  // a global object for node.js module compatiblity
+  // ============================================
+
+  context['global'] = context
+
+  // Implements simple module system
+  // losely based on CommonJS Modules spec v1.1.1
+  // ============================================
+
+  var modules = {}
+    , old = context.$
+
+  function require (identifier) {
+    // modules can be required from ender's build system, or found on the window
+    var module = modules[identifier] || window[identifier]
+    if (!module) throw new Error("Requested module '" + identifier + "' has not been defined.")
+    return module
+  }
+
+  function provide (name, what) {
+    return (modules[name] = what)
+  }
+
+  context['provide'] = provide
+  context['require'] = require
+
+  function aug(o, o2) {
+    for (var k in o2) k != 'noConflict' && k != '_VERSION' && (o[k] = o2[k])
+    return o
+  }
+
+  function boosh(s, r, els) {
+    // string || node || nodelist || window
+    if (typeof s == 'string' || s.nodeName || (s.length && 'item' in s) || s == window) {
+      els = ender._select(s, r)
+      els.selector = s
+    } else els = isFinite(s.length) ? s : [s]
+    return aug(els, boosh)
+  }
+
+  function ender(s, r) {
+    return boosh(s, r)
+  }
+
+  aug(ender, {
+      _VERSION: '0.3.6'
+    , fn: boosh // for easy compat to jQuery plugins
+    , ender: function (o, chain) {
+        aug(chain ? boosh : ender, o)
+      }
+    , _select: function (s, r) {
+        return (r || document).querySelectorAll(s)
+      }
+  })
+
+  aug(boosh, {
+    forEach: function (fn, scope, i) {
+      // opt out of native forEach so we can intentionally call our own scope
+      // defaulting to the current item and be able to return self
+      for (i = 0, l = this.length; i < l; ++i) i in this && fn.call(scope || this[i], this[i], i, this)
+      // return self for chaining
+      return this
+    },
+    $: ender // handy reference to self
+  })
+
+  ender.noConflict = function () {
+    context.$ = old
+    return this
+  }
+
+  if (typeof module !== 'undefined' && module.exports) module.exports = ender
+  // use subscript notation as extern for Closure compilation
+  context['ender'] = context['$'] = context['ender'] || ender
+
+}(this);
+
+!function () {
+
+  var module = { exports: {} }, exports = module.exports;
+
+  /**
+   Radio.js - Chainable, Dependency Free Publish/Subscribe for Javascript
+   http://radio.uxder.com
+   Author: Scott Murphy 2011
+   twitter: @hellocreation, github: uxder
+   
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use,
+   copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following
+   conditions:
+   
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+   
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+   OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+   OTHER DEALINGS IN THE SOFTWARE.
+   */
+  (function (name, global, definition) {
+  	if (typeof module !== 'undefined') module.exports = definition(name, global);
+  	else if (typeof define === 'function' && typeof define.amd  === 'object') define(definition);
+  	else global[name] = definition(name, global);
+  })('radio', this, function (name, global) {
+  
+  	"use strict";
+  
+  	/**
+  	 * Main Wrapper for radio.$ and create a function radio to accept the channelName
+  	 * @param {String} channelName topic of event
+  	 */
+  	function radio(channelName) {
+  		radio.$.channel(channelName);
+  		return radio.$;
+  	}
+  
+  	radio.$ = {
+  		version: '0.1.0',
+  		channelName: "",
+  		channels: [],
+  		/**
+  		 * Broadcast (publish)
+  		 * Iterate through all listeners (callbacks) in current channel and pass arguments to subscribers
+  		 * @param arguments data to be sent to listeners
+  		 * @example
+  		 *    //basic usage
+  		 *    radio('channel1').broadcast('my message'); 
+  		 *    //send an unlimited number of parameters
+  		 *    radio('channel2').broadcast(param1, param2, param3 ... );
+  		 */
+  		broadcast: function() {
+  			var i, c = this.channels[this.channelName],
+  				l = c.length,
+  				subscriber, callback, context;
+  			//iterate through current channel and run each subscriber
+  			for (i = 0; i < l; i++) {
+  				subscriber = c[i];
+  				//if subscriber was an array, set the callback and context.
+  				if ((typeof(subscriber) === 'object') && (subscriber.length)) {
+  					callback = subscriber[0];
+  					//if user set the context, set it to the context otherwise, it is a globally scoped function
+  					context = subscriber[1] || global;
+  				}
+  				callback.apply(context, arguments);
+  			}
+  			return this;
+  		},
+  
+  		/**
+  		 * Create the channel if it doesn't exist and set the current channel/event name
+  		 * @param {String} name the name of the channel
+  		 * @example
+  		 *    radio('channel1');
+  		 */
+  		channel: function(name) {
+  			var c = this.channels;
+  			//create a new channel if it doesn't exists
+  			if (!c[name]) c[name] = [];
+  			this.channelName = name;
+  			return this;
+  		},
+  
+  		/**
+  		 * Add Subscriber to channel
+  		 * Take the arguments and add it to the this.channels array.
+  		 * @param {Function|Array} arguments list of callbacks or arrays[callback, context] separated by commas
+  		 * @example
+  		 *      //basic usage
+  		 *      var callback = function() {};
+  		 *      radio('channel1').add(callback); 
+  		 *
+  		 *      //add an endless amount of callbacks
+  		 *      radio('channel1').add(callback, callback2, callback3 ...);
+  		 *
+  		 *      //adding callbacks with context
+  		 *      radio('channel1').add([callback, context],[callback1, context], callback3);
+  		 *     
+  		 *      //add by chaining
+  		 *      radio('channel1').add(callback).radio('channel2').add(callback).add(callback2);
+  		 */
+  		add: function() {
+  			var a = arguments,
+  				c = this.channels[this.channelName],
+  				i, l = a.length,
+  				p, ai = [];
+  
+  			//run through each arguments and add it to the channel
+  			for (i = 0; i < l; i++) {
+  				ai = a[i];
+  				//if the user sent just a function, wrap the fucntion in an array [function]
+  				p = (typeof(ai) === "function") ? [ai] : ai;
+  				if ((typeof(p) === 'object') && (p.length)) c.push(p);
+  			}
+  			return this;
+  		},
+  
+  		/**
+  		 * Remove subscriber from channel
+  		 * Take arguments with functions and remove it if there is a match against existing subscribers.
+  		 * @param {Function} arguments callbacks separated by commas
+  		 * @example
+  		 *      //basic usage
+  		 *      radio('channel1').remove(callback); 
+  		 *      //you can remove as many callbacks as you want
+  		 *      radio('channel1').remove(callback, callback2, callback3 ...);
+  		 *       //removing callbacks with context is the same
+  		 *      radio('channel1').add([callback, context]).remove(callback);
+  		 */
+  		remove: function() {
+  			var a = arguments,
+  				i, j, c = this.channels[this.channelName],
+  				l = a.length,
+  				cl = c.length,
+  				offset = 0,
+  				jo;
+  			//loop through each argument
+  			for (i = 0; i < l; i++) {
+  				//need to reset vars that change as the channel array items are removed
+  				offset = 0;
+  				cl = c.length;
+  				//loop through the channel
+  				for (j = 0; j < cl; j++) {
+  					jo = j - offset;
+  					//if there is a match with the argument and the channel function, remove it from the channel array
+  					if (c[jo][0] === a[i]) {
+  						//remove matched item from the channel array
+  						c.splice(jo, 1);
+  						offset++;
+  					}
+  				}
+  			}
+  			return this;
+  		}
+  	};
+  
+  	return radio;
+  });
+  
+
+  provide("radio", module.exports);
+
+  (function ($) {
+    var radio = require('radio');
+  
+    function integrate(meth) {
+      return function() {
+        var r = radio(arguments[0]);
+        return r[meth].apply(r, Array.prototype.slice.call(arguments, 1));
+      }
+    }
+  
+    $.ender({
+      subscribe: integrate('add'),
+      unsubscribe: integrate('remove'),
+      broadcast: integrate('broadcast')
+    });
+  }(ender))
+  
+
+}();

--- a/tests/ender/integration.html
+++ b/tests/ender/integration.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html>
+<head>
+  <title>Ender Integration Tests</title>
+  <script src="ender.js"></script>
+  <style type="text/css">
+    body { font-family: 'helvetica neue', helvetica, arial; font-size: 11pt; }
+    p { margin: 5px; }
+    .fail { color: red; }
+    .pass { color: green; }
+  </style>
+</head>
+<body>
+
+<script type="text/javascript">
+  var res, fn, ctx;
+
+  function result (success, msg) {
+    var r = document.createElement('p'),
+      s = success ? 'Pass' : 'Fail';
+    r.innerHTML = '<b>' + s + '</b>: ' + msg;
+    r.className = s.toLowerCase();
+    document.body.appendChild(r);
+  }
+
+  res = false;
+  $.subscribe('test1', function() { res = true; });
+  $.broadcast('test1');
+  result(res, 'simple subscribe &amp; broadcast');
+
+  res = false;
+  $.subscribe('test2', function(data) { res = data === 101; });
+  $.broadcast('test2', 101);
+  result(res, 'single argument subscribe &amp; broadcast');
+
+  res = false;
+  $.subscribe('test3', function() { res = arguments[0] === 101 && arguments[1] === 202 && arguments[2] === 303; });
+  $.broadcast('test3', 101, 202, 303);
+  result(res, 'multi argument subscribe &amp; broadcast');
+
+  res = 0;
+  fn = function() { res++; };
+  $.subscribe('test4', fn)
+  $.broadcast('test4');
+  $.broadcast('test4');
+  $.unsubscribe('test4', fn)
+  $.broadcast('test4');
+  result(res === 2, 'subscribe, multi-broadcast &amp; unsubscribe');
+
+  res = false;
+  ctx = {};
+  $.subscribe('test5', [ function() { res = this === ctx; }, ctx ]);
+  $.broadcast('test5');
+  result(res, 'subscribe &amp; broadcast with context');
+
+  res = 0;
+  $.subscribe('test6', function() { res++ });
+  $.subscribe('test6', function() { res++ });
+  $.broadcast('test6');
+  result(res === 2, 'multiple subscribers');
+
+  res = 0;
+  $.subscribe('test7', function() { res++ }, function() { res++ });
+  $.broadcast('test7');
+  result(res === 2, 'multi-argument subscribe');
+
+  res = 0;
+  fn = function() { res++; };
+  $.subscribe('test8', fn).broadcast('test8').broadcast('test8').remove('test8', fn).broadcast('test8');
+  result(res === 2, 'chained subscribe, multi-broadcast &amp; unsubscribe');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Hi Scott, great little library you have here! I'm submitting this PR for your consideration, it's mainly about adding [Ender](http://ender.no.de) support so it can be easily included in an Ender build.
- Added a _package.json_ so it can go in to NPM, you'll need to do an `npm publish` on the commandline, I've left that for you.
- Adjusted _radio.js_ so that it follows a generic CommonJS Module & AMD pattern but still does what it did prior to modification (the only necessary bit was to replace `window` with `this` but I thought I may as well add the whole-hog for you!).
- Added an Ender bridge in the form of the _ender.js_ file. This simply does the mapping from your script to the Ender ($) object. Instead of `$.add()` and `$.remove()` I went with `$.subscribe()` and `$.unsubscribe()` to avoid obvious name clashes with other Ender modules. But `add` and `remove` are still available if you access the `radio` object with `require('radio')` (a global method with Ender), so `require('radio').add(x).broadcast(y).remove(x)` would work the same as `$.subscribe(x).broadcast(y).subscribe(x)`.
- Added integration tests for Ender. The _integration.html_ file has all the tests in it and should show all the usage possibilities when integrated with Ender. The _ender.js_ is a simple Ender build file that was generated from that directory using `ender build ../..` (path to the root directory containing package.json). When Radio is in NPM then `ender build radio` would generate the same file.
