### PR TITLE
check amd first

### DIFF
--- a/radio.js
+++ b/radio.js
@@ -26,8 +26,8 @@
  OTHER DEALINGS IN THE SOFTWARE.
  */
 (function (name, global, definition) {
-  if (typeof module !== 'undefined') module.exports = definition(name, global);
-  else if (typeof define === 'function' && typeof define.amd  === 'object') define(definition);
+  if (typeof define === 'function' && typeof define.amd  === 'object') define(definition);
+  else if (typeof 'exports' !== 'undefined' && typeof module !== 'undefined') module.exports = definition(name, global);
   else global[name] = definition(name, global);
 })('radio', this, function (name, global) {
 


### PR DESCRIPTION
`radio` is `undefined` while loading it in Karma test runner with amd. The issue is the that in Karma `module` is defined so, the code assumes that it's common js module. Should add the check amd first.
